### PR TITLE
Disable pnpm strict-dep-builds in stable-install-modes guard

### DIFF
--- a/scripts/assert-stable-install-modes.mjs
+++ b/scripts/assert-stable-install-modes.mjs
@@ -85,6 +85,14 @@ function run(command, args, cwd, env = {}) {
         COREPACK_ENABLE_AUTO_PIN: '0',
         PNPM_CONFIG_FROZEN_LOCKFILE: 'false',
         npm_config_frozen_lockfile: 'false',
+        // pnpm 11.0.7+ promoted "ignored build scripts" from a warning to a
+        // fatal `ERR_PNPM_IGNORED_BUILDS`. Temp fixtures created here pull in
+        // `@parcel/watcher` (transitive of `@rspack/dev-server@^2`) which has
+        // an unapproved build script, so a fresh pnpm install in the fixture
+        // dies before the canary even runs. Restore the pnpm 10 behaviour
+        // (warn-only) so this guard exercises canary install paths, not
+        // pnpm's policy-of-the-week.
+        PNPM_CONFIG_STRICT_DEP_BUILDS: 'false',
         ...env
       }
     })


### PR DESCRIPTION
## Why

pnpm 11.0.7+ turned the previously-warning \`ignored build scripts\` into a fatal \`ERR_PNPM_IGNORED_BUILDS\`. Inside \`scripts/assert-stable-install-modes.mjs\`, the temp fixtures install \`@parcel/watcher\` transitively (via \`@rspack/dev-server@^2\`); its build script is unapproved in the freshly-copied fixture, so \`pnpm install\` dies before the canary CLI even runs.

This is what's making the 8 pnpm-mode assertions fail in [run 25494125419 / job 74809414463](https://github.com/extension-js/examples/actions/runs/25494125419/job/74809414463). The same canary passes in bun, npm, and yarn modes — proof it's a pnpm-policy change, not a canary regression.

## Change

Add \`PNPM_CONFIG_STRICT_DEP_BUILDS: 'false'\` to the spawn env in the \`run()\` helper. pnpm 11 falls back to pnpm-10 behaviour (warn instead of fail) for ignored build scripts. The guard's job is exercising canary install paths, not gating on pnpm's policy-of-the-week for build-script approval.

## Test plan

- [ ] Re-run \`Examples CI / optional-deps-guards\` against latest canary (\`extension@3.15.1-canary.local-fda8403864\`) on a clean ubuntu-latest runner with corepack-pinned pnpm 11.0.8.
- [ ] All 4 PMs (npm, pnpm, yarn, bun) × 7 examples should pass.