### PR TITLE
TypeScript template: add allowImportingTsExtensions to tsconfig

### DIFF
--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -15,7 +15,8 @@
     "target": "esnext",
     "verbatimModuleSyntax": false,
     "useDefineForClassFields": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["./", "extension-env.d.ts", "browser-global.d.ts"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

- Importing files with a `.ts` extension resulted in a `tsc` warning
- This fixes it.

## Test plan

- [ ] Automated tests updated or not needed
- [x] Manual testing completed
- [x] Docs updated or not needed
